### PR TITLE
Enable NestJS' ValidationPipe feature

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,7 @@
     ]
   ],
   "plugins": [
+    "babel-plugin-transform-typescript-metadata",
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     "babel-plugin-parameter-decorator"
   ]

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "@types/node": "^13.11.1",
     "@types/react": "^16.9.34",
     "babel-plugin-parameter-decorator": "^1.0.16",
+    "babel-plugin-transform-typescript-metadata": "^0.3.2",
     "reflect-metadata": "^0.1.13",
     "ts-node": "^8.8.2",
-    "typescript": "^3.8.3"
+    "typescript": "^4.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,6 +2000,13 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
+babel-plugin-transform-typescript-metadata@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-typescript-metadata/-/babel-plugin-transform-typescript-metadata-0.3.2.tgz#7a327842d8c36ffe07ee1b5276434e56c297c9b7"
+  integrity sha512-mWEvCQTgXQf48yDqgN7CH50waTyYBeP2Lpqx4nNWab9sxEpdXVeKgfj1qYI2/TgUPQtNFZ85i3PemRtnXVYYJg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
@@ -6042,10 +6049,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Apart of adding the `babel-plugin-transform-typescript-metadata` plugin it was also needed to upgrade typescript in the dependencies as well from v3 to v4. With v3 the validation was throwing error even when all the parameters were provided correctly.

-----
_Original issue description:_

Setting up the validation as described in NestJS documentation would expect to
get BadRequestException, but it doesn't take it into consideration.

Way I tried can be found here:
https://github.com/Skn0tt/nextjs-nestjs-integration-example/compare/master...szabolcs-szilagyi:validation-pipe?expand=1

``` shell
$ curl --no-progress-meter 'http://localhost:3000/api/randomNumber/pipe-test?randomNumber=33' | jq .
{
  "numberNameDto": {
    "randomNumber": "33",
    "catchAll": [
      "randomNumber",
      "pipe-test"
    ]
  }
}
```

Tried the same setup with a new nestjs app there it worked. Also oddly it looks
like the dto is completely ignored in the function signature: we also get the
`catchAll` parameter.

Think this is some babel magic again, but not sure.